### PR TITLE
Use UTC timestamp to sign request.

### DIFF
--- a/lib/simple-cloudfront-invalidator.rb
+++ b/lib/simple-cloudfront-invalidator.rb
@@ -36,7 +36,7 @@ module SimpleCloudfrontInvalidator
     private
 
     def sign_and_call(url, method, body = nil)
-      date = Time.now.strftime("%a, %d %b %Y %H:%M:%S %Z")
+      date = Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S %Z")
       digest = Base64.encode64(
         OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'), @aws_secret, date)).strip
       uri = URI.parse(url)


### PR DESCRIPTION
Requests are currently signed with local time but Amazon expects UTC time, which can cause errors like:

``` xml
<?xml version="1.0"?>
<ErrorResponse xmlns="http://cloudfront.amazonaws.com/doc/2012-05-05/">
  <Error>
    <Type>Sender</Type>
    <Code>RequestExpired</Code>
    <Message>Request has expired. Time stamp date is Thu, 01 Aug 2013 18:24:43 EST.</Message>
  </Error>
  <RequestId>d2009762-fa83-11e2-b688-298917308a3e</RequestId>
</ErrorResponse>
```
