### PR TITLE
Digest::Digest is deprecated; use Digest

### DIFF
--- a/lib/simple-cloudfront-invalidator.rb
+++ b/lib/simple-cloudfront-invalidator.rb
@@ -38,7 +38,7 @@ module SimpleCloudfrontInvalidator
     def sign_and_call(url, method, body = nil)
       date = Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S %Z")
       digest = Base64.encode64(
-        OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'), @aws_secret, date)).strip
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), @aws_secret, date)).strip
       uri = URI.parse(url)
       req = method.new(uri.path)
       req.initialize_http_header({


### PR DESCRIPTION
This fixes a warning that I have been seeing when using the **1.x** branch of [**s3_website**](https://github.com/laurilehmijoki/s3_website)