### PR TITLE
Update Travis config and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
-- 1.8.7
+- 2.2
+- 2.1
+- 2.0
 - 1.9.2
 - 1.9.3

--- a/spec/simple_cloudfront_invalidator_spec.rb
+++ b/spec/simple_cloudfront_invalidator_spec.rb
@@ -14,11 +14,11 @@ module SimpleCloudfrontInvalidator
     end
 
     it 'returns a textual report on the invalidation' do
-      textual_report = @report[:text_report]
-      textual_report.join('').should include("Invalidating Cloudfront items...")
-      textual_report.join('').should include("/index.html")
-      textual_report.join('').should include("/articles.html")
-      textual_report.join('').should include("succeeded")
+      textual_report = @report[:text_report].join('')
+      expect(textual_report).to include "Invalidating Cloudfront items..."
+      expect(textual_report).to include "/index.html"
+      expect(textual_report).to include "/articles.html"
+      expect(textual_report).to include "succeeded"
     end
 
     it 'returns the count of successfully invalidated items' do


### PR DESCRIPTION
Dropped Ruby `1.8.7` because [**webmock**](https://rubygems.org/gems/webmock) requires [**addressable**](https://rubygems.org/gems/addressable), which no longer plays nice with anything earlier than 1.9.